### PR TITLE
Override podman default mounts

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -20,6 +20,17 @@
       - podman
     state: present
 
+- name: Create an empty mounts.conf to override podman default mounts
+  # See also: man containers-mounts.conf (shipped by containers-common)
+  # This is to avoid host repos being injected into OSBS image builds
+  copy:
+    content: ""
+    dest: /etc/containers/mounts.conf
+    force: true
+    group: root
+    owner: root
+    mode: 0664
+
 - name: Install machinectl to start podman service
   dnf:
     name:


### PR DESCRIPTION
Some distributions may ship a /usr/share/containers/mounts.conf
file to provide default mounts, for example, RHEL ships this file
with content:

    /usr/share/rhel/secrets:/run/secrets

which mounts the repos available in host subscription to container,
this should be prevented by overriding the default mounts.conf.

With rootless podman, this can also be overrided by
$HOME/.config/containers/mounts.conf, but /etc/containers/mounts.conf
seems a better solution for all cases.

* CLOUDBLD-8521

Signed-off-by: Qixiang Wan <qwan@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
