### PR TITLE
Misc enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ Dependencies
 
 None.
 
-Required Variables
+Role Variables
 ------------
 
-Required:
-podman_user: username for running rootless podman socket
-podman_user_uid: uid for the user
+### Input
+
+* `podman_user_group_name` - group name of the user running rootless podman. Default: osbs-podman.
+* `podman_user_group_gid` - gid of the group. Default: 2022.
+* `podman_user_name` - name of the user running rootless podman. Default: osbs-podman.
+* `podman_user_uid` - uid of the user running rootless podman. Default: 2022.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+podman_user_name: osbs-podman
+podman_user_uid: 2022
+podman_user_group_name: osbs-podman
+podman_user_group_gid: 2022

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -21,5 +21,9 @@
     state: present
 
 - name: Enable and start rootless podman.socket
+  # rootless podman backend need to be started with a login session, so
+  # ansible become methods ("sudo", "su" and etc) don't work in this
+  # case, become method "machinectl" is not flexible enough to fulfill
+  # the requirement either, run machinectl command as a workaround
   command: machinectl shell {{ podman_user }}@.host /usr/bin/systemctl --user enable --now podman.socket
   changed_when: false

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,11 +1,17 @@
 ---
-- name: Create user accounts
+- name: Create group for user running rootless podman
+  group:
+    name: "{{ podman_user_group_name }}"
+    gid: "{{ podman_user_group_gid }}"
+
+- name: Create user for running rootless podman
   user:
-    name: "{{ podman_user }}"
+    name: "{{ podman_user_name }}"
     uid: "{{ podman_user_uid }}"
+    group: "{{ podman_user_group_name }}"
 
 - name: Enable persistent user session to allow running long-running services without logged in
-  command: loginctl enable-linger {{ podman_user }}
+  command: loginctl enable-linger {{ podman_user_name }}
   changed_when: false
 
 - name: Install Podman on RHEL8 server
@@ -25,5 +31,5 @@
   # ansible become methods ("sudo", "su" and etc) don't work in this
   # case, become method "machinectl" is not flexible enough to fulfill
   # the requirement either, run machinectl command as a workaround
-  command: machinectl shell {{ podman_user }}@.host /usr/bin/systemctl --user enable --now podman.socket
+  command: machinectl shell {{ podman_user_name }}@.host /usr/bin/systemctl --user enable --now podman.socket
   changed_when: false


### PR DESCRIPTION
* Document why running machinectl command to start rootless podman

Be more explicit with user/group creation:
* Rename `podman_user` to `podman_user_name`
* Set group name, gid explicitly
* Add defaults for user name, uid, group name and gid.
* Update README.md accordingly

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
