### PR TITLE
Support running and connecting podman backend with different users

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Role Variables
 * `podman_user_group_gid` - gid of the group. Default: 2022.
 * `podman_user_name` - name of the user running rootless podman backend. Default: osbs-podman.
 * `podman_user_uid` - uid of the user running rootless podman backend. Default: 2022.
+* `podman_user_subordinate_uid_start` - subordinate uid starts from. Default: 100000.
+* `podman_user_subordinate_uid_count` - subordinate uid count. Default: 1878948191.
+* `podman_user_subordinate_gid_start` - subordinate gid starts from. Default: 100000.
+* `podman_user_subordinate_gid_count` - subordinate gid count. Default: 1878948191.
 * `podman_ssh_user_name` - ssh user login name for connecting remote podman backend.
 * `podman_ssh_user_public_key` - ssh public key for user which is used to connect remote podman backend.
 * `podman_pruning_interval_minutes` - minutes interval for podman pruning job

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Role Variables
 
 ### Input
 
-* `podman_user_group_name` - group name of the user running rootless podman. Default: osbs-podman.
+* `podman_user_group_name` - group name of the user running rootless podman backend. Default: osbs-podman.
 * `podman_user_group_gid` - gid of the group. Default: 2022.
-* `podman_user_name` - name of the user running rootless podman. Default: osbs-podman.
-* `podman_user_uid` - uid of the user running rootless podman. Default: 2022.
-* `podman_user_ssh_public_key` - public key for podman user ssh and podman-remote access
+* `podman_user_name` - name of the user running rootless podman backend. Default: osbs-podman.
+* `podman_user_uid` - uid of the user running rootless podman backend. Default: 2022.
+* `podman_ssh_user_name` - ssh user login name for connecting remote podman backend.
+* `podman_ssh_user_public_key` - ssh public key for user which is used to connect remote podman backend.
 * `podman_pruning_interval_minutes` - minutes interval for podman pruning job
 * `podman_pruning_until` - until for podman pruning command
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,10 @@ podman_user_name: osbs-podman
 podman_user_uid: 2022
 podman_user_group_name: osbs-podman
 podman_user_group_gid: 2022
+# These subordinate numbers are picked per doc: https://systemd.io/UIDS-GIDS
+podman_user_subordinate_uid_start: 100000
+podman_user_subordinate_uid_count: 1878948191  # 1879048191 - 100000
+podman_user_subordinate_gid_start: 100000
+podman_user_subordinate_gid_count: 1878948191  # 1879048191 - 100000
 podman_pruning_until: "10m"
 podman_pruning_interval_minutes: "2"

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -5,3 +5,6 @@
 
 - name: restart rootless podman
   command: machinectl shell {{ podman_user_name }}@.host /usr/bin/systemctl --user restart podman.socket
+
+- name: migrate podman containers
+  command: podman system migrate

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: reload systemd
+  # Only reload daemon, use command module since systemd module doesn't support this
+  command: systemctl daemon-reload  # noqa command-instead-of-module
+
+- name: restart rootless podman
+  command: machinectl shell {{ podman_user_name }}@.host /usr/bin/systemctl --user restart podman.socket

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -10,22 +10,40 @@
     uid: "{{ podman_user_uid }}"
     group: "{{ podman_user_group_name }}"
 
-- name: Setup authorized keys for podman user
+- name: Setup authorized keys for podman ssh user
   authorized_key:
-    user: "{{ podman_user_name }}"
-    key: "{{ podman_user_ssh_public_key }}"
+    user: "{{ podman_ssh_user_name if podman_ssh_user_name is defined else podman_user_name }}"
+    key: "{{ podman_ssh_user_public_key }}"
     manage_dir: true
-  when: podman_user_ssh_public_key is defined
+  when: podman_ssh_user_public_key is defined
 
 - name: Enable persistent user session to allow running long-running services without logged in
   command: loginctl enable-linger {{ podman_user_name }}
   changed_when: false
+
+- name: Add podman ssh user to podman run user group
+  user:
+    name: "{{ podman_ssh_user_name }}"
+    groups: "{{ podman_user_group_name }}"
+    append: true
+  when: podman_ssh_user_name is defined and podman_ssh_user_name != podman_user_name
 
 - name: Install Podman on RHEL8 server
   dnf:
     name:
       - podman
     state: present
+
+- name: Copy podman.socket systemd user config file
+  template:
+    src: "systemd/user/podman.socket.j2"
+    dest: "/usr/lib/systemd/user/podman.socket"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - reload systemd
+    - restart rootless podman
 
 - name: Create an empty mounts.conf to override podman default mounts
   # See also: man containers-mounts.conf (shipped by containers-common)

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -10,6 +10,24 @@
     uid: "{{ podman_user_uid }}"
     group: "{{ podman_user_group_name }}"
 
+- name: Set subordinate user/group IDs for podman user
+  lineinfile:
+    path: "{{ item.path }}"
+    line: "{{ item.line }}"
+    regexp: "{{ item.regex }}"
+    create: true
+    state: present
+    mode: 0644
+  with_items:
+    - path: "/etc/subuid"
+      regex: "^{{ podman_user_name }}:"
+      line: "{{ podman_user_name }}:{{ podman_user_subordinate_uid_start }}:{{ podman_user_subordinate_uid_count }}"
+    - path: "/etc/subgid"
+      regex: "^{{ podman_user_group_name }}:"
+      line: "{{ podman_user_group_name }}:{{ podman_user_subordinate_gid_start }}:{{ podman_user_subordinate_gid_count }}"
+  notify:
+    - migrate podman containers
+
 - name: Setup authorized keys for podman ssh user
   authorized_key:
     user: "{{ podman_ssh_user_name if podman_ssh_user_name is defined else podman_user_name }}"

--- a/templates/systemd/user/podman.socket.j2
+++ b/templates/systemd/user/podman.socket.j2
@@ -1,0 +1,15 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=Podman API Socket
+Documentation=man:podman-system-service(1)
+
+[Socket]
+ListenStream=%t/podman/podman.sock
+SocketMode=0660
+{% if podman_ssh_user_name is defined and podman_ssh_user_name != podman_user_name %}
+ExecStartPost=/bin/sh -c '[[ _"$LOGNAME" == _"{{podman_user_name}}" ]] && chmod 0750 %t || /bin/true'
+{% endif %}
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Changes:

1. Add a new variable `podman_ssh_user_name`, name of user which is used
   to connect remote podman backend.

2. Rename `podman_user_ssh_public_key` to `podman_ssh_user_public_key`

3. When `podman_ssh_user_name` is defined and different with
   `podman_user_name`, `podman_ssh_user_name` will be added to group of
   `podman_user_group_name`, and `podman_user_name`'s systemd user
   runtime directory permission will be changed to `0750` (default is
   `0700`) when rootless podman backend is started by `podman_user_name`.

* CLOUDBLD-8941

Signed-off-by: Qixiang Wan <qwan@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
