### PR TITLE
Enable user lingering for ssh user

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -39,6 +39,11 @@
   command: loginctl enable-linger {{ podman_user_name }}
   changed_when: false
 
+- name: Enable user lingering for ssh user to create systemd user runtime directory when system boot up
+  command: loginctl enable-linger {{ podman_ssh_user_name }}
+  when: podman_ssh_user_name is defined and podman_ssh_user_name != podman_user_name
+  changed_when: false
+
 - name: Add podman ssh user to podman run user group
   user:
     name: "{{ podman_ssh_user_name }}"


### PR DESCRIPTION
Enable user lingering for ssh user when the ssh user is not the user for
running podman backend. This will make systemd to create the user runtime
directory ($XDG_RUNTIME_DIR: /run/user/{uid}) when system boot up, then
we can use this directory for creating OSBS slots dir/files.

Signed-off-by: Qixiang Wan <qwan@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
