### PR TITLE
Change start number of subuid/subgid for osbs-podman user/group

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Role Variables
 * `podman_user_group_gid` - gid of the group. Default: 2022.
 * `podman_user_name` - name of the user running rootless podman backend. Default: osbs-podman.
 * `podman_user_uid` - uid of the user running rootless podman backend. Default: 2022.
-* `podman_user_subordinate_uid_start` - subordinate uid starts from. Default: 100000.
+* `podman_user_subordinate_uid_start` - subordinate uid starts from. Default: 10000000.
 * `podman_user_subordinate_uid_count` - subordinate uid count. Default: 1878948191.
-* `podman_user_subordinate_gid_start` - subordinate gid starts from. Default: 100000.
+* `podman_user_subordinate_gid_start` - subordinate gid starts from. Default: 10000000.
 * `podman_user_subordinate_gid_count` - subordinate gid count. Default: 1878948191.
 * `podman_ssh_user_name` - ssh user login name for connecting remote podman backend.
 * `podman_ssh_user_public_key` - ssh public key for user which is used to connect remote podman backend.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,11 @@ podman_user_uid: 2022
 podman_user_group_name: osbs-podman
 podman_user_group_gid: 2022
 # These subordinate numbers are picked per doc: https://systemd.io/UIDS-GIDS
-podman_user_subordinate_uid_start: 100000
+# subuid/subgid starts from 10_000_000, so there are still 10000000-100000
+# IDs available for new users on host. check `man useradd` for more details.
+podman_user_subordinate_uid_start: 10000000
 podman_user_subordinate_uid_count: 1878948191  # 1879048191 - 100000
-podman_user_subordinate_gid_start: 100000
+podman_user_subordinate_gid_start: 10000000
 podman_user_subordinate_gid_count: 1878948191  # 1879048191 - 100000
 podman_pruning_until: "10m"
 podman_pruning_interval_minutes: "2"


### PR DESCRIPTION
The subuid and subgid starts from 10_000 for osbs-podman, and the count
is pretty large 1_878_948_191, this prevents new users to be created on
hosts with default settings of SUB_UID_MIN, SUB_GID_MIN and etc.

man useradd:

    SUB_UID_MIN (number), SUB_UID_MAX (number), SUB_UID_COUNT (number)

    If /etc/subuid exists, the commands useradd and newusers (unless the
    user already have subordinate user IDs) allocate SUB_UID_COUNT unused
    user IDs from the range SUB_UID_MIN to SUB_UID_MAX for each new user.

    The default values for SUB_UID_MIN, SUB_UID_MAX, SUB_UID_COUNT are
    respectively 100000, 600100000 and 65536.

so with the default values, all IDs between 100_000 and 600100000 have
already been allocated for our osbs-podman user. Changing the start
number to 10_000_000 makes it possible to create ~151 new users on host:

    (10_000_000-100_000)/65536 ~= 151

Signed-off-by: Qixiang Wan <qwan@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
