### PR TITLE
Set runtime dir permission to 770

### DIFF
--- a/templates/systemd/user/podman.socket.j2
+++ b/templates/systemd/user/podman.socket.j2
@@ -8,7 +8,7 @@ Documentation=man:podman-system-service(1)
 ListenStream=%t/podman/podman.sock
 SocketMode=0660
 {% if podman_ssh_user_name is defined and podman_ssh_user_name != podman_user_name %}
-ExecStartPost=/bin/sh -c '[[ _"$LOGNAME" == _"{{podman_user_name}}" ]] && chmod 0750 %t || /bin/true'
+ExecStartPost=/bin/sh -c '[[ _"$LOGNAME" == _"{{podman_user_name}}" ]] && chmod 0770 %t || /bin/true'
 {% endif %}
 
 [Install]


### PR DESCRIPTION
Increase group permissions for runtime directory so it can read/write/execute

CLOUDBLD-8995

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
