### PR TITLE
Reload user systemd instead of system-wide systemd

### DIFF
--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -1,7 +1,7 @@
 ---
-- name: reload systemd
-  # Only reload daemon, use command module since systemd module doesn't support this
-  ansible.builtin.command: systemctl daemon-reload  # noqa command-instead-of-module
+- name: reload systemd for podman user
+  # Only reload daemon
+  ansible.builtin.command: machinectl shell {{ podman_user_name }}@.host /usr/bin/systemctl --user daemon-reload
 
 - name: restart rootless podman
   ansible.builtin.command: machinectl shell {{ podman_user_name }}@.host /usr/bin/systemctl --user restart podman.socket

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -65,7 +65,7 @@
     group: root
     mode: 0644
   notify:
-    - reload systemd
+    - reload systemd for podman user
     - restart rootless podman
 
 - name: Copy podman.service systemd user config file
@@ -76,7 +76,7 @@
     group: root
     mode: 0644
   notify:
-    - reload systemd
+    - reload systemd for podman user
     - restart rootless podman
 
 - name: Create an empty mounts.conf to override podman default mounts


### PR DESCRIPTION
The 'reload systemd' handler was used to reload upon changes to the unit
files used by the podman user. But we need to reload the user units, not
the system-wide units. Run systemctl --user daemon-reload as osbs-podman
to fix this.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
