### PR TITLE
Set LimitNOFILE for osbs-podman systemd manager

### DIFF
--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -8,3 +8,10 @@
 
 - name: migrate podman containers
   ansible.builtin.command: podman system migrate
+
+- name: restart podman user session
+  # note: we use the system-wide systemd here, not podman user's systemd --user
+  ansible.builtin.systemd:
+    unit: user@{{ podman_user_uid }}.service
+    state: restarted
+    daemon_reload: true

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -79,6 +79,24 @@
     - reload systemd for podman user
     - restart rootless podman
 
+- name: Create drop-in configuration directory for podman user systemd service
+  ansible.builtin.file:
+    path: "/etc/systemd/system/user@{{ podman_user_uid }}.service.d"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Apply overrides to podman user systemd service
+  ansible.builtin.template:
+    src: "systemd/system/user@insert-uid.service.d/override.conf.j2"
+    dest: "/etc/systemd/system/user@{{ podman_user_uid }}.service.d/override.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart podman user session
+
 - name: Create an empty mounts.conf to override podman default mounts
   # See also: man containers-mounts.conf (shipped by containers-common)
   # This is to avoid host repos being injected into OSBS image builds

--- a/templates/systemd/system/user@insert-uid.service.d/override.conf.j2
+++ b/templates/systemd/system/user@insert-uid.service.d/override.conf.j2
@@ -1,0 +1,7 @@
+{{ ansible_managed | comment }}
+
+# Overrides for the `systemd --user` service for the OSBS Podman user.
+
+[Service]
+# The default soft limit of 1024 is not sufficient. Inherit limits from systemd (PID 1)
+LimitNOFILE=infinity


### PR DESCRIPTION
We recently saw `systemd --user` reach the soft limit of 1024 open
files, at which point many things stopped working, inluding the podman
service and socket.

Increase the limit to avoid this problem in the future.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
