### PR TITLE
Fix pruning cronjob interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Role Variables
 * `podman_user_subordinate_gid_count` - subordinate gid count. Default: 1878948191.
 * `podman_ssh_user_name` - ssh user login name for connecting remote podman backend.
 * `podman_ssh_user_public_key` - ssh public key for user which is used to connect remote podman backend.
-* `podman_pruning_interval_minutes` - minutes interval for podman pruning job
+* `podman_pruning_interval_minutes` - minutes interval for podman pruning job (the maximum is 59)
 * `podman_pruning_until` - until for podman pruning command
 
 Example Playbook

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -139,6 +139,6 @@
 - name: Add podman pruning cronjob
   ansible.builtin.cron:
     name: "podman pruner"
-    minute: "{{ podman_pruning_interval_minutes }}"
+    minute: "*/{{ podman_pruning_interval_minutes }}"
     user: "{{ podman_user_name }}"
     job: 'podman system prune --all --filter "until={{ podman_pruning_until }}" -f'


### PR DESCRIPTION
The current configuration makes the job run e.g. [at minute 2][0].
We want to run the job [at every 2nd minute][1].

[0]: https://crontab.guru/#2_*_*_*_*
[1]: https://crontab.guru/#*/2_*_*_*_*

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
