### PR TITLE
Add buildah container pruner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Role Variables
 * `podman_ssh_user_public_key` - ssh public key for user which is used to connect remote podman backend.
 * `podman_pruning_interval_minutes` - minutes interval for podman pruning job (the maximum is 59)
 * `podman_pruning_until` - until for podman pruning command
+* `buildah_pruning_enabled` - enable the buildah container pruner? Default true.
+* `buildah_pruning_interval_hours` - hours interval for the buildah pruner (the maximum is 23)
+* `buildah_pruning_before` - prune buildah containers older than this, e.g. '6 hours ago'
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,7 @@ podman_user_subordinate_gid_count: 1878948191  # 1879048191 - 100000
 podman_pruning_until: "10m"
 podman_pruning_interval_minutes: "2"
 podman_nofile_limit: 1024
+
+buildah_pruning_enabled: true
+buildah_pruning_interval_hours: "1"
+buildah_pruning_before: "6 hours ago"

--- a/files/prune-buildah-containers.sh
+++ b/files/prune-buildah-containers.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+usage() {
+    cat << EOF
+usage: $0 before [remote_connection]
+
+Prune external containers (e.g. buildah containers) older than the specified
+date. Such containers do not get pruned by podman's default pruning mechanisms.
+
+args:
+    before: date --date=\$before (a timestamp, an ISO date, '1 day ago', ...)
+    remote_connection: podman-remote connection name (default local machine)
+EOF
+}
+
+before=${1:-''}
+remote_connection=${2:-''}
+
+if [[ -z "$before" ]]; then
+    usage >&2
+    exit 1
+fi
+
+if [[ -n "$remote_connection" ]]; then
+    podman=(podman --remote --connection "$remote_connection")
+else
+    podman=(podman)
+fi
+
+before_ts=$(date +%s --date="$before")
+containers_to_remove=$(
+    "${podman[@]}" container ls -a --external --format json |
+    jq -c --argjson before_ts "$before_ts" \
+        '.[] | select(.Created < $before_ts and .Status == "Storage") | {Id, Names}'
+)
+
+if [[ -z "$containers_to_remove" ]]; then
+    echo "Nothing to remove."
+else
+    echo "Containers to remove:"
+    jq -r '"Id=\(.Id) Name=\(.Names[0])"' <<< "$containers_to_remove"
+    jq -r '.Id' <<< "$containers_to_remove" | xargs -n 10 "${podman[@]}" container rm -f
+fi

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -142,3 +142,37 @@
     minute: "*/{{ podman_pruning_interval_minutes }}"
     user: "{{ podman_user_name }}"
     job: 'podman system prune --all --filter "until={{ podman_pruning_until }}" -f'
+
+- name: Set up buildah container pruner
+  block:
+    - name: Sanity-check buildah_pruning_before
+      ansible.builtin.command:
+        argv:
+          - date
+          - --date
+          - '{{ buildah_pruning_before }}'
+      changed_when: false
+
+    - name: Install jq (prerequisite for buildah pruning script)
+      ansible.builtin.dnf:
+        name:
+          - jq
+        state: present
+
+    - name: Copy buildah pruning script
+      ansible.builtin.copy:
+        src: prune-buildah-containers.sh
+        dest: /usr/local/bin/prune-buildah-containers.sh
+        force: true
+        group: root
+        owner: root
+        mode: 0775
+
+    - name: Add buildah pruning cronjob
+      ansible.builtin.cron:
+        name: "buildah container pruner"
+        minute: "0"
+        hour: "*/{{ buildah_pruning_interval_hours }}"
+        user: "{{ podman_user_name }}"
+        job: "/usr/local/bin/prune-buildah-containers.sh '{{ buildah_pruning_before }}'"
+  when: buildah_pruning_enabled


### PR DESCRIPTION
CLOUDBLD-10965

In exceptional cases, podman builds may leave behind intermediate buildah containers. These containers are not managed by podman, so our current pruner job ignores them. This can sometimes prevent the pruner from removing images as well - it only removes images that do not have associated containers.

Add a searate job for pruning buildah containers. It is implemented as a custom script, because the `podman container prune` command does not support removing buildah containers.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
