### PR TITLE
workflow: use checkout action version 3

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run ansible-lint
         uses: containerbuildsystem/actions/ansible-lint@master


### PR DESCRIPTION
Older versions run with unsupported nodejs

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
