### PR TITLE
Add tags for pruning

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -148,6 +148,7 @@
   changed_when: false
 
 - name: Add podman pruning cronjob
+  tags: pruning
   ansible.builtin.cron:
     name: "podman pruner"
     minute: "*/{{ podman_pruning_interval_minutes }}"
@@ -155,6 +156,7 @@
     job: 'podman system prune --all --filter "until={{ podman_pruning_until }}" -f'
 
 - name: Set up buildah container pruner
+  tags: pruning
   block:
     - name: Sanity-check buildah_pruning_before
       ansible.builtin.command:


### PR DESCRIPTION
We don't need to run everything for pruning configuration

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
