### PR TITLE
fix(podman): increase system NOFILE limit and...

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -127,16 +127,6 @@
     group: root
     mode: 0644
 
-- name: Apply overrides to podman user systemd service
-  ansible.builtin.template:
-    src: "systemd/system/user@insert-uid.service.d/override.conf.j2"
-    dest: "/etc/systemd/system/user@{{ podman_user_uid }}.service.d/override.conf"
-    owner: root
-    group: root
-    mode: 0644
-  notify:
-    - restart podman user session
-
 - name: Create separate rhsm.conf for mounting into containers
   ansible.builtin.copy:
     content: |
@@ -162,16 +152,23 @@
     owner: root
     mode: 0664
 
-- name: Increase file hard/soft limits in /e/s/limits.d
-  ansible.builtin.copy:
-    content: |
-      * hard nofile 1048576
-      * soft nofile unlimited
-    dest: /etc/security/limits.d/01-file-limits.conf
-    force: true
+- name: Apply 50-file-limits.conf to systemd/system
+  # Overrides system NOFILE limit
+  ansible.builtin.template:
+    src: "systemd/system/50-file-limits.conf.j2"
+    dest: "/etc/systemd/system.conf.d/50-file-limits.conf"
     group: root
     owner: root
     mode: 0644
+
+- name: Apply /etc/containers/containers.conf
+  # Currently, only increases NOFILE limit
+  ansible.builtin.template:
+    src: "containers/containers.conf.j2"
+    dest: "/etc/containers/containers.conf"
+    group: root
+    owner: root
+    mode: 0664
 
 - name: Install machinectl to start podman service
   ansible.builtin.dnf:

--- a/templates/containers/containers.conf.j2
+++ b/templates/containers/containers.conf.j2
@@ -1,0 +1,4 @@
+[containers]
+default_ulimits = [
+  "nofile={{ podman_nofile_limit }}:{{ podman_nofile_limit }}",
+]

--- a/templates/systemd/system/50-file-limits.conf.j2
+++ b/templates/systemd/system/50-file-limits.conf.j2
@@ -1,0 +1,2 @@
+[Manager]
+DefaultLimitNOFILE={{ podman_nofile_limit }}:{{ podman_nofile_limit }}

--- a/templates/systemd/system/user@insert-uid.service.d/override.conf.j2
+++ b/templates/systemd/system/user@insert-uid.service.d/override.conf.j2
@@ -1,7 +1,0 @@
-{{ ansible_managed | comment }}
-
-# Overrides for the `systemd --user` service for the OSBS Podman user.
-
-[Service]
-# The default soft limit of 1024 is not sufficient. Inherit limits from systemd (PID 1)
-LimitNOFILE=infinity

--- a/templates/systemd/user/podman.service.j2
+++ b/templates/systemd/user/podman.service.j2
@@ -12,7 +12,6 @@ Type=exec
 KillMode=process
 Environment=LOGGING="--log-level=info"
 ExecStart=/usr/bin/podman $LOGGING system service
-LimitNOFILE={{ podman_nofile_limit }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
...increase container.conf NOFILE limit

- Add template for /etc/containers/containers.conf
- Move NOFILE limits from /etc/security/limits.d/01-file-limits.conf to (templated) /etc/systemd/system.conf.d/50-file-limits.conf
- No longer add useless /etc/systemd/system/user@insert-uid.service.d/override.conf
- Remove useless NOFILE limits from /etc/systemd/user/podman.service


CLOUDBLD-11273

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
