### PR TITLE
user for rootless podman doesn't need shell so use /sbin/nologin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@ podman_user_name: osbs-podman
 podman_user_uid: 2022
 podman_user_group_name: osbs-podman
 podman_user_group_gid: 2022
+podman_shell: "/sbin/nologin"
 # These subordinate numbers are picked per doc: https://systemd.io/UIDS-GIDS
 # subuid/subgid starts from 10_000_000, so there are still 10000000-100000
 # IDs available for new users on host. check `man useradd` for more details.

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -9,6 +9,7 @@
     name: "{{ podman_user_name }}"
     uid: "{{ podman_user_uid }}"
     group: "{{ podman_user_group_name }}"
+    shell: "{{ podman_shell }}"
 
 - name: Set subordinate user/group IDs for podman user
   ansible.builtin.lineinfile:


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
